### PR TITLE
Raw type 'Class' should be parameterized

### DIFF
--- a/src/main/java/org/morganm/homespawnplus/command/CommandRegister.java
+++ b/src/main/java/org/morganm/homespawnplus/command/CommandRegister.java
@@ -173,7 +173,7 @@ public class CommandRegister {
         SimpleCommandMap commandMap = null;
 
         PluginManager pm = plugin.getServer().getPluginManager();
-        Class clazz = pm.getClass();
+        Class<? extends PluginManager> clazz = pm.getClass();
         Field field = null;
         try {
             field = clazz.getDeclaredField("commandMap");


### PR DESCRIPTION
Class is a raw type. References to generic type Class<T> should be parameterized.
