### PR TITLE
Updated HomeSpawnUtils.isNewPlayer() to support 1.7.9

### DIFF
--- a/src/main/java/org/morganm/homespawnplus/HomeSpawnUtils.java
+++ b/src/main/java/org/morganm/homespawnplus/HomeSpawnUtils.java
@@ -973,17 +973,24 @@ public class HomeSpawnUtils {
     		
     		final List<World> worlds = Bukkit.getWorlds();
     		final String worldName = worlds.get(0).getName();
-        	File file;
-        	
-        	
-         file = new File(worldContainer, worldName + "/playerdata/" + p.getUniqueId() + ".dat");
+    		
+         // Player data location is checked against both of these directories
+         // to provide support for both the old (prior to 1.7.9) and new
+         // (1.7.9 and later) locations and file names
+         File playerDatOldLoc = new File(worldContainer, worldName + "/player/" + p.getName() + ".dat");
+         File playerDatNewLoc = new File(worldContainer, worldName + "/playerdata/" + p.getUniqueId() + ".dat");
          
-        	if( file.exists() ) {
-        		debug.debug("isNewPlayer: using ",strategy," strategy, ",file," exists, player is NOT new");
+        	if( playerDatOldLoc.exists() ) {
+        		debug.debug("isNewPlayer: using ",strategy," strategy, ",playerDatOldLoc," exists, player is NOT new");
         		return false;
         	}
 
-    		debug.debug("isNewPlayer: using ",strategy," strategy, ",file," does not exist");
+         if( playerDatNewLoc.exists() ) {
+            debug.debug("isNewPlayer: using ",strategy," strategy, ",playerDatNewLoc," exists, player is NOT new");
+            return false;
+         }
+         
+    		debug.debug("isNewPlayer: using ",strategy," strategy, ",p.getName() + "/" + p.getUniqueId()," does not exist");
     	}
     	
 		debug.debug("isNewPlayer: using ",strategy," strategy, player is determined to be NEW player");


### PR DESCRIPTION
Updated HomeSpawnUtils.isNewPlayer() to support 1.7.9. This method breaks with the new player UUIDs and it not backwards compatible.

If it is possible to detect whether the server version is older than 1.7.9 then a backwards-compatible update and be pushed at a later date. I don't know how to do this and have asked the appropriate question on the bukkit forums.
