### PR TITLE
Rewrite of StrategyConfigImpl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dependency-reduced-pom.xml
 .idea
 release.properties
 **/pom.xml.releaseBackup
+**/nb-configuration.xml

--- a/core/src/main/java/com/andune/minecraft/hsp/strategy/EventType.java
+++ b/core/src/main/java/com/andune/minecraft/hsp/strategy/EventType.java
@@ -44,8 +44,8 @@ public enum EventType {
     CROSS_WORLD_TELEPORT("crossWorldTeleport"),
     MULTIVERSE_TELEPORT_CROSSWORLD("multiverseCrossWorldTeleport"),
     MULTIVERSE_TELEPORT("multiverseTeleport"),
-    ENTER_REGION("onregionenter"),
-    EXIT_REGION("onregionexit"),
+    ENTER_REGION("onRegionEnter"),
+    EXIT_REGION("onRegionExit"),
     NEW_PLAYER("onNewPlayer"),
     TELEPORT_OBSERVE("onTeleportObserve"),
     FALL_THROUGH_WORLD("onFallThroughWorld");


### PR DESCRIPTION
I've intruduced internal class StrategySet as Set of strategies, WorldStrategies and PermissionStrategies are children for new internal StrategyMap. This allowed to shorten the code in load***Strategies().

Check and test it, please. I suppose all should be fine.